### PR TITLE
Flow Screen and User Object Icon Issue

### DIFF
--- a/force-app/main/default/classes/DynamicDataTableHandler.cls
+++ b/force-app/main/default/classes/DynamicDataTableHandler.cls
@@ -203,7 +203,7 @@ public with sharing class DynamicDataTableHandler {
             iconName='standard:';
         }
         String iconQuery='SELECT (SELECT Url FROM Icons WHERE ContentType LIKE \'image/svg%\') FROM TabDefinition WHERE SobjectName =\'' + objToken + '\'';
-        TabDefinition tabDefinitionRecord = (TabDefinition)Database.query(iconQuery);
+        TabDefinition tabDefinitionRecord = (TabDefinition)Database.query(iconQuery)[0];
         if (tabDefinitionRecord.Icons != null ) {
             String iconUrl = tabDefinitionRecord.Icons[0].Url; 
             List<String> urlParts = iconUrl.split('/');

--- a/force-app/main/default/lwc/dynamicDataTable/dynamicDataTable.js
+++ b/force-app/main/default/lwc/dynamicDataTable/dynamicDataTable.js
@@ -58,7 +58,7 @@ export default class DynamicDataTable extends LightningElement {
     filteredData = [];
     @api checkForFilteredList;
     @api checkBoxVisibile = false;
-    @api showtoggle;
+    @api showtoggle = false;
 
 
     connectedCallback() {


### PR DESCRIPTION
1- When using datasource as SOQL in flows for the first time, the table data appeared blank. The issue stemmed from the 
    showToggle property defaulting to false in the dynamicDatatable.js-meta.xml file, and being placed without any value in 
    dynamicDatatable.js. Consequently, in the Lightning App and Record pages, showToggle was set to false by default from the 
    meta.xml file. However, in flows, the property value was undefined since it wasn't getting the default value from meta.xml. To 
    resolve this, the showToggle property in the JS file was explicitly set to false, fixing the issue.

2- The User Object icons were not displaying correctly due to the presence of two conflicting SVG files.This issue has now been 
     resolved, ensuring that the User Object icons appear as intended.